### PR TITLE
Update draw.io version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>draw.io</artifactId>
-      <version>6.5.7</version>
+      <version>27.0.9</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- bump draw.io from 6.5.7 to 27.0.9

## Testing
- `mvn -q verify` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68544965dd9483218313a302c6c842aa