### PR TITLE
Fix DiagramTranslations description line

### DIFF
--- a/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/src/main/resources/Diagram/DiagramTranslations.xml
@@ -59,7 +59,7 @@ diagram.livetable.emptyvalue=-
 rendering.macro.diagram.name=Diagram
 rendering.macro.diagram.description=Displays a diagram.
 rendering.macro.diagram.parameter.reference.name=Reference
-rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=The reference of the page that contains the diagram to display. E.g. for "http://.../Diagram/My%20Diagram/", enter "Diagram.My Diagram.WebHome". If this field is left blank, the macro looks for a child page named "Diagram" and if not found, displays a form to create a diagram.
+rendering.macro.diagram.parameter.reference.description=The reference of the page that contains the diagram to display. E.g. for "http://.../Diagram/My%20Diagram/", enter "Diagram.My Diagram.WebHome". If this field is left blank, the macro looks for a child page named "Diagram" and if not found, displays a form to create a diagram.
 rendering.macro.diagram.parameter.cached.name=Cached
 rendering.macro.diagram.parameter.cached.description=Whether to display the cached diagram image (faster) instead of rendering the diagram live (slower).
 diagram.macro.invalidReference=The specified page is not a diagram.
@@ -67,7 +67,8 @@ diagram.macro.viewNotAllowed=You are not allowed to view this diagram.
 diagram.macro.createNotAllowed=You are not allowed to create this diagram.
 diagram.macro.view=View diagram
 diagram.macro.edit=Edit diagram
-diagram.macro.create=Create diagram</content>
+diagram.macro.create=Create diagram
+</content>
   <object>
     <name>Diagram.DiagramTranslations</name>
     <number>0</number>


### PR DESCRIPTION
## Summary
- fix translation key duplication in DiagramTranslations
- put `</content>` closing tag on a new line

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68545611f6bc8321a080147cd0b6e70c