### PR TITLE
Fix Maven build configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,18 @@
     <!-- There are no java resources in this project. --> 
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
   </properties>
+  <repositories>
+    <repository>
+      <id>xwiki-nexus</id>
+      <url>https://nexus.xwiki.org/nexus/content/groups/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>xwiki-nexus</id>
+      <url>https://nexus.xwiki.org/nexus/content/groups/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -91,7 +103,7 @@
     <dependency>
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>draw.io</artifactId>
-      <version>27.0.9</version>
+      <version>24.5.5-3</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- add XWiki Nexus repository for parent POM and plugins
- update draw.io dependency version to one that exists

## Testing
- `JAVA_TOOL_OPTIONS='-Dhttp.proxyHost=proxy -Dhttp.proxyPort=8080 -Dhttps.proxyHost=proxy -Dhttps.proxyPort=8080 -Djava.net.preferIPv4Stack=true' mvn -DskipTests package -e`

------
https://chatgpt.com/codex/tasks/task_b_685488eb0190832189083e969cb6aaa5