### PR TITLE
Fix viewer error handling

### DIFF
--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -274,8 +274,12 @@ require.config({
       lightbox: false
     }, options);
     return this.each(function() {
-      var xmlDoc = mxUtils.parseXml($(this).data('model'));
-      new GraphViewer(this, xmlDoc.documentElement, options);
+      try {
+        var xmlDoc = mxUtils.parseXml($(this).data('model'));
+        new GraphViewer(this, xmlDoc.documentElement, options);
+      } catch (e) {
+        $(this).text('Unable to load diagram');
+      }
     }).removeClass('loading');
   };
 


### PR DESCRIPTION
## Summary
- handle XML parsing errors in DiagramViewSheet viewer JS

## Testing
- `mvn -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6854aa4ecaf48321ba6a701e39c05abe