### PR TITLE
Fix Maven build in workflow

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>xwiki</id>
+      <name>XWiki Public Mirror</name>
+      <url>https://nexus.xwiki.org/nexus/content/groups/public/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: '11'
       - name: Build with Maven
-        run: mvn -B package
+        run: mvn -B package --settings .github/maven-settings.xml
       - name: Publish Release
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
## Summary
- configure Maven to use XWiki public repository
- invoke Maven with settings in GitHub workflow

## Testing
- `mvn -B package --settings .github/maven-settings.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6855d71d06f883219543caf469498ada