### PR TITLE
Clarify draw.io sources and update Maven settings

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -1,12 +1,6 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <mirrors>
-    <mirror>
-      <id>xwiki</id>
-      <name>XWiki Public Mirror</name>
-      <url>https://nexus.xwiki.org/nexus/content/groups/public/</url>
-      <mirrorOf>central</mirrorOf>
-    </mirror>
-  </mirrors>
+  <!-- Use default Maven Central repository and configure the XWiki repository
+       only for the dependencies explicitly declared in the POM. -->
 </settings>

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This is a simple application created using [AppWithinMinutes](http://extensions.
 * Sonar Dashboard: N/A
 * Continuous Integration Status: [![Build Status](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-diagram/job/master/badge/icon)](https://ci.xwiki.org/view/Contrib/job/XWiki%20Contrib/job/application-diagram/job/master/)
 
+The `drawio_sources` directory stores a copy of the upstream draw.io source code.
+These files are provided only as a reference when upgrading the embedded
+draw.io WebJar and they are **not** used during the build of the Diagram
+Application.
+
 ## Updating to a newer draw.io version
 
 This repository used to bundle an outdated `draw.io` WebJar (`6.5.7`). The dependency


### PR DESCRIPTION
## Summary
- document that `drawio_sources` is only for reference
- remove XWiki Nexus mirror from GitHub Maven settings

## Testing
- `mvn -B package --settings .github/maven-settings.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6855dbe847d88321854abe39f8f56bef