### PR TITLE
Update draw.io integration and debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Create various types of diagrams using [draw.io](https://www.draw.io/).
 
 This is a simple application created using [AppWithinMinutes](http://extensions.xwiki.org/xwiki/bin/view/Extension/App+Within+Minutes+Application) and integrating [jgraph/draw.io](https://github.com/jgraph/draw.io/). It supports both editing and viewing diagrams. Each diagram is stored in a wiki page. It doesn't require any external services in order to work properly.
 
+## Development Notes
+
+All updates to this application should be documented in this file to keep track
+of integration work and upgrade steps. Always mention the draw.io version in use
+and note any important changes or debugging improvements.
+
 * Project Lead: [Oana-Lavinia Florean](https://www.xwiki.org/xwiki/bin/view/XWiki/OanaLaviniaFlorean)
 * [Documentation & Download](https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram+Application)
 * [Issue Tracker](https://jira.xwiki.org/browse/XADIAGRAM)
@@ -23,9 +29,9 @@ Application.
 
 ## Updating to a newer draw.io version
 
-This repository used to bundle an outdated `draw.io` WebJar (`6.5.7`). The dependency
-has been updated to `24.5.5` using the sources under `drawio_sources`. When upgrading the application
-make sure to:
+This repository used to bundle an outdated `draw.io` WebJar (`6.5.7`).
+The dependency was later switched to `24.5.5` and now targets `27.0.9` using the
+sources under `drawio_sources`. When upgrading the application make sure to:
 
 1. Replace the old WebJar dependency in `pom.xml` with a WebJar built from the provided sources.
 2. Keep the current integration logic (editor initialization, macro code, storage format) so that diagrams
@@ -34,6 +40,17 @@ make sure to:
    compatibility with earlier versions of the application.
 4. Ensure that no additional external services are enabled in the new `draw.io` build to preserve the
    self-contained nature of this application.
+
+To build a WebJar locally run the following commands inside `drawio_sources/drawio`:
+
+```
+mvn -Pwebjar clean package
+mvn install:install-file -Dfile=target/draw.io-webjar-27.0.9.jar \
+    -DgroupId=org.xwiki.contrib -DartifactId=draw.io -Dversion=27.0.9 -Dpackaging=jar
+```
+
+The second command installs the freshly built WebJar in your local Maven repository so
+that the Diagram Application can depend on it during development.
 
 These guidelines will help updating the code base while maintaining full backward compatibility with
 existing XWiki installations.

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>draw.io</artifactId>
       <!-- Use a draw.io WebJar available on the XWiki Nexus -->
-      <version>24.5.5</version>
+      <version>27.0.9</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -339,16 +339,20 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
       return this.title;
     },
     getData: function() {
+      console.debug('Getting diagram data from input', this.input.attr('name'));
       return this.input.val();
     },
     setData: function(data) {
+      console.debug('Setting diagram data for input', this.input.attr('name'));
       this.input.val(data);
     },
     updateFileData: function() {
       // We overwrite the base implementation because we don't want to support files that contain multiple diagrams.
+      console.debug('Updating stored diagram data');
       this.setData(mxUtils.getPrettyXml(this.ui.editor.getGraphXml()));
     },
     open: function() {
+      console.debug('Opening diagram file');
       var graphXML = this.getData() || '&lt;mxGraphModel/&gt;';
       this.ui.editor.setGraphXml(mxUtils.parseXml(graphXML).documentElement);
       this.changeListener = mxUtils.bind(this, function(sender, eventObject) {
@@ -381,9 +385,13 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     };
 
   // We need to update the form fields before the form is validated (for Preview, Save and Save &amp; Continue).
-  $(document).on('xwiki:actions:beforePreview xwiki:actions:beforeSave', updateFormFields);
+  $(document).on('xwiki:actions:beforePreview xwiki:actions:beforeSave', function() {
+    console.debug('xwiki:actions:beforePreview/beforeSave event');
+    updateFormFields();
+  });
 
   $(document).on('xwiki:actions:beforeSave', function() {
+    console.debug('Preparing diagram SVG before save');
     forEachOpenedFile(function(file) {
       var svgInput = file.input.next('.diagram-svg');
       if (svgInput.length &gt; 0) {
@@ -400,6 +408,7 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
       // We reset the dirty field on 'xwiki:actions:save' only if it's not a Save &amp; Continue. Otherwise we wait for
       // 'xwiki:document:saved' to be sure the document was saved.
       if (!data || !data['continue']) {
+        console.debug('Handling action', event.type);
         submitInProgress = event.type === 'xwiki:actions:preview' || event.type === 'xwiki:actions:save';
         resetDirty();
       }
@@ -409,6 +418,7 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     // Update the form fields before the page is unloaded in order to allow the browser to cache their values
     // (Back-Forward and Soft Reload cache). The form fields have already been updated (for validation) if a submit
     // is currently in progress.
+    console.debug('beforeunload event');
     if (!submitInProgress) {
       updateFormFields();
     } else {


### PR DESCRIPTION
## Summary
- add development notes and update instructions
- bump draw.io webjar version
- improve debug logging in the diagram editor

## Testing
- `mvn test` *(fails: Could not transfer artifact org.xwiki.contrib:parent-platform)*

------
https://chatgpt.com/codex/tasks/task_b_6855e1138de883218931af571c0a4770