### PR TITLE
Improve diagram XML debug logging

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -354,7 +354,10 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     open: function() {
       console.debug('Opening diagram file');
       var graphXML = this.getData() || '&lt;mxGraphModel/&gt;';
-      this.ui.editor.setGraphXml(mxUtils.parseXml(graphXML).documentElement);
+      console.debug('Parsing diagram XML', graphXML);
+      var graphDocument = mxUtils.parseXml(graphXML);
+      console.debug('Parsed diagram DOM', graphDocument.documentElement);
+      this.ui.editor.setGraphXml(graphDocument.documentElement);
       this.changeListener = mxUtils.bind(this, function(sender, eventObject) {
         this.setModified(true);
       });

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -291,7 +291,10 @@ require.config({
         version: typeof EditorUi !== 'undefined' ? EditorUi.VERSION : mxClient.VERSION
       });
       return this.each(function() {
-        var xmlDoc = mxUtils.parseXml($(this).data('model'));
+        var xmlString = $(this).data('model');
+        console.debug('Parsing diagram XML', xmlString);
+        var xmlDoc = mxUtils.parseXml(xmlString);
+        console.debug('Parsed diagram DOM', xmlDoc.documentElement);
         console.debug('Displaying diagram element', xmlDoc.documentElement);
         new GraphViewer(this, xmlDoc.documentElement, options);
       }).removeClass('loading');


### PR DESCRIPTION
## Summary
- extend debug logs in edit sheet when parsing diagram XML
- log XML parsing steps in view sheet

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855e3f8b2a88321b91230e79dd0717a