### PR TITLE
Update build instructions for draw.io

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: '11'
           cache: maven
       - name: Clone draw.io packaging project
-        run: git clone https://github.com/xwiki-contrib/draw.io.git /tmp/drawio
+        run: git clone https://github.com/seclution/draw.io.git /tmp/drawio
       - name: Build draw.io WebJar
         run: mvn -Pwebjar clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio

--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ Diagram Application.
 ## Updating to a newer draw.io version
 
 This repository used to bundle an outdated `draw.io` WebJar (`6.5.7`).
-The dependency was later switched to `24.5.5` and now targets `27.0.9`.
+The dependency was later switched to `24.5.5` and now targets `27.1.6`.
 The WebJar should be built using the
-[`xwiki-contrib/draw.io`](https://github.com/xwiki-contrib/draw.io)
-repository. When upgrading the application make sure to:
+[`seclution/draw.io`](https://github.com/seclution/draw.io)
+repository which contains the updated packaging. When upgrading the application
+make sure to:
 
 1. Replace the old WebJar dependency in `pom.xml` with a WebJar built from
-   `xwiki-contrib/draw.io`.
+   `seclution/draw.io`.
 2. Keep the current integration logic (editor initialization, macro code, storage format) so that diagrams
    created with older versions can still be opened and saved without changes.
 3. Verify that existing diagrams render correctly with the new editor and that saving them doesn't break
@@ -46,10 +47,13 @@ repository. When upgrading the application make sure to:
 
 To build a WebJar locally perform the following steps:
 
-1. Clone `https://github.com/xwiki-contrib/draw.io`.
+1. Clone `https://github.com/seclution/draw.io`.
 2. Run `mvn -Pwebjar clean package` inside the cloned repository.
 3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
    local Maven cache.
+
+The forked repository keeps the draw.io sources up to date and can be used as
+a starting point for additional build customization.
 
 The `draw.io-api` module is not required for this application unless you need
 server-side features.

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>draw.io</artifactId>
       <!-- Use a draw.io WebJar available on the XWiki Nexus -->
-      <version>27.0.9</version>
+      <version>27.1.6</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary
- reference seclution/draw.io fork when rebuilding WebJar
- bump draw.io version to 27.1.6
- clone fork in workflow

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855eaecca9c8321834cbd48a014ca55