### PR TITLE
Improve logging for diagram module

### DIFF
--- a/src/main/resources/Diagram/DiagramEditSheet.xml
+++ b/src/main/resources/Diagram/DiagramEditSheet.xml
@@ -353,7 +353,11 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     },
     open: function() {
       console.debug('Opening diagram file');
-      var graphXML = this.getData() || '&lt;mxGraphModel/&gt;';
+      var graphXML = this.getData();
+      if (!graphXML) {
+        console.warn('No diagram data found; starting with empty graph');
+        graphXML = '&lt;mxGraphModel/&gt;';
+      }
       console.debug('Parsing diagram XML', graphXML);
       var graphDocument = mxUtils.parseXml(graphXML);
       console.debug('Parsed diagram DOM', graphDocument.documentElement);
@@ -366,6 +370,9 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
   });
 
   var forEachOpenedFile = function(visitor) {
+    if (files.length === 0) {
+      console.warn('No diagram files currently opened');
+    }
     files.forEach(function(file) {
       if (file.getUi() &amp;&amp; file.getUi().getCurrentFile() === file) {
         visitor(file);
@@ -400,6 +407,8 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
       if (svgInput.length &gt; 0) {
         var svgRoot = file.getUi().editor.graph.getSvg('#ffffff', true, false, false, null, true);
         svgInput.val(mxUtils.getXml(svgRoot));
+      } else {
+        console.warn('SVG input not found for', file.input.attr('name'));
       }
     });
   });
@@ -738,6 +747,7 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
   var bundle = mxResources.getDefaultBundle(RESOURCE_BASE, mxLanguage) ||
     mxResources.getSpecialBundle(RESOURCE_BASE, mxLanguage);
   mxUtils.getAll([bundle, STYLE_PATH + '/default.xml'], function(response) {
+    console.debug('Editor resources loaded');
     // Adds bundle text to resources.
     mxResources.parse(response[0].getText());
 
@@ -745,8 +755,9 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
     themes[Graph.prototype.defaultThemeName] = response[1].getDocumentElement();
 
     diagramEditorDeferred.resolve();
-  }, function() {
+  }, function(error) {
     // Failed to load resources.
+    console.error('Failed to load editor resources', error);
     diagramEditorDeferred.reject();
   });
 
@@ -849,6 +860,8 @@ define('diagramStore', ['jquery', 'draw.io', 'xwiki-events-bridge'], function($)
   diagramEditorPromise.done(function() {
       console.debug('Diagram editor module loaded');
       $('.diagram-editor').editDiagram();
+    }).fail(function(error) {
+      console.error('Failed to initialize diagram editor', error);
     });
 });</code>
     </property>

--- a/src/main/resources/Diagram/DiagramViewSheet.xml
+++ b/src/main/resources/Diagram/DiagramViewSheet.xml
@@ -292,6 +292,9 @@ require.config({
       });
       return this.each(function() {
         var xmlString = $(this).data('model');
+        if (!xmlString) {
+          console.warn('No diagram model found for viewer');
+        }
         console.debug('Parsing diagram XML', xmlString);
         var xmlDoc = mxUtils.parseXml(xmlString);
         console.debug('Parsed diagram DOM', xmlDoc.documentElement);
@@ -308,9 +311,9 @@ require.config({
       Graph.prototype.defaultThemes = Graph.prototype.defaultThemes || {};
       Graph.prototype.defaultThemes[Graph.prototype.defaultThemeName] = response.getDocumentElement();
       diagramViewerDeferred.resolve();
-    }, function() {
+    }, function(error) {
       // Failed to load the theme.
-      console.debug('Failed to load viewer theme');
+      console.error('Failed to load viewer theme', error);
       diagramViewerDeferred.reject();
     });
 
@@ -413,6 +416,8 @@ require.config({
   diagramViewerPromise.done(function() {
       console.debug('Diagram viewer module loaded');
       $('.diagram').viewDiagram();
+    }).fail(function(error) {
+      console.error('Failed to initialize diagram viewer', error);
     });
 });</code>
     </property>


### PR DESCRIPTION
## Summary
- add warnings for missing diagram data or SVG input
- report failure to load editor resources and viewer themes
- show warnings when no diagram files are open
- log initialization failures in editor and viewer

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6855f16029c083218eb24c5a8dff1bda