### PR TITLE
Update workflows to use Java 17

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
           cache: maven
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
       - name: Build with Maven
         run: mvn -B package --settings .github/maven-settings.xml
       - name: Publish Release


### PR DESCRIPTION
## Summary
- use Java 17 in build-drawio-webjar workflow
- use Java 17 in release workflow

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f7cf2c7c8321b54f0e267d165f08