### PR TITLE
Document editor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Diagram Application
 Create various types of diagrams using [draw.io](https://www.draw.io/).
 
 This is a simple application created using [AppWithinMinutes](http://extensions.xwiki.org/xwiki/bin/view/Extension/App+Within+Minutes+Application) and integrating [jgraph/draw.io](https://github.com/jgraph/draw.io/). It supports both editing and viewing diagrams. Each diagram is stored in a wiki page. It doesn't require any external services in order to work properly.
+See [docs/integration.md](docs/integration.md) for details on how the editor is embedded and configured.
 
 ## Development Notes
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,41 @@
+# Diagram Editor Integration
+
+This document explains how `DiagramEditSheet.xml` embeds the draw.io editor, stores diagrams inside wiki pages and disables external services for offline usage.
+
+## Editor initialization
+
+`DiagramEditSheet.xml` defines a JavaScript extension that configures RequireJS and loads the draw.io modules. The editor paths are computed from the embedded WebJars:
+
+```
+var mxGraphEditorBasePath = "$services.webjars.url('org.xwiki.contrib:mxgraph-editor', '')";
+var diagramEditorBasePath = "$services.webjars.url('org.xwiki.contrib:draw.io', '')";
+```
+
+A custom `diagramEditor` module creates an `EditorUi` instance and loads the diagram file from the current page using `diagramStore.createFile`.
+
+## Storing diagrams
+
+The `diagramStore` module (defined in the same file) reads the diagram XML from a hidden input field and updates it whenever the graph model changes. Only a single diagram is stored per page, so `updateFileData()` simply serializes the current `graphXml` back into the input element.
+
+## Disabling external services
+
+To keep the application self‑contained, URL parameters and global variables disable online integrations:
+
+```
+var urlParams = {
+  'splash': '0',
+  'pages': '0',
+  'gh': '0',   // GitHub
+  'db': '0',   // Dropbox
+  'gapi': '0', // Google Drive
+  'analytics': '0',
+  'od': '0'    // OneDrive
+};
+var DriveFile = DropboxFile = GitHubFile = OneDriveFile = false;
+```
+
+These settings ensure that the editor does not attempt to contact external APIs.
+
+## Source reference
+
+See [`src/main/resources/Diagram/DiagramEditSheet.xml`](../src/main/resources/Diagram/DiagramEditSheet.xml) for the full Velocity and JavaScript code used to integrate draw.io.


### PR DESCRIPTION
## Summary
- link new integration notes in README
- add docs/integration.md explaining how `DiagramEditSheet.xml` loads draw.io, stores diagrams, and disables remote services

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855f7d3d5188321b8390e9fadd45345