### PR TITLE
Add script to update draw.io WebJar version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ To build a WebJar locally perform the following steps:
 2. Run `mvn -Pwebjar clean package` inside the cloned repository.
 3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
    local Maven cache.
+4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
+   to update the dependency version in `pom.xml`.
 
 The forked repository keeps the draw.io sources up to date and can be used as
 a starting point for additional build customization.
@@ -104,8 +106,8 @@ section above.
 1. Clone the repository and run `mvn -Pwebjar clean package`.
 2. Optionally install the generated jar with `mvn -pl draw.io-webjar install` so
    that it can be resolved by this project.
-3. Ensure the `pom.xml` depends on your newly built WebJar (groupId
-   `org.xwiki.contrib`, artifactId `draw.io`, and the version you just built).
+3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
+   to update `pom.xml` with the WebJar version you just built.
 4. From the root of this repository run `mvn package` to generate the XAR under
    `target/`.
 

--- a/scripts/update-webjar-version.sh
+++ b/scripts/update-webjar-version.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <path-to-draw.io-webjar> [--commit]" >&2
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+JAR_PATH="$1"
+COMMIT="${2:-}"
+
+if [ ! -f "$JAR_PATH" ]; then
+    echo "File not found: $JAR_PATH" >&2
+    exit 1
+fi
+
+JAR_FILE="$(basename "$JAR_PATH")"
+VERSION="${JAR_FILE#draw.io-}"
+VERSION="${VERSION%.jar}"
+
+# Update pom.xml dependency version
+xmlstarlet ed -L \
+    -u "/_:project/_:dependencies/_:dependency[_:groupId='org.xwiki.contrib'][_:artifactId='draw.io']/_:version" \
+    -v "$VERSION" pom.xml
+
+echo "Updated pom.xml to use draw.io version $VERSION"
+
+if [ "$COMMIT" = "--commit" ]; then
+    if [ -n "$(git status --porcelain pom.xml)" ]; then
+        git add pom.xml
+        git commit -m "chore: update draw.io WebJar to $VERSION"
+    else
+        echo "No changes to commit"
+    fi
+fi


### PR DESCRIPTION
## Summary
- create `scripts/update-webjar-version.sh` to update pom.xml
- document the new helper script in README

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6855f7d2db1c8321b9eeeac36164d49a