### PR TITLE
Add workflow syncing draw.io version

### DIFF
--- a/.github/workflows/sync-drawio-sources.yml
+++ b/.github/workflows/sync-drawio-sources.yml
@@ -1,0 +1,32 @@
+name: Sync draw.io sources
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+      - name: Determine draw.io version
+        id: vars
+        run: |
+          VERSION=$(grep -A2 "<artifactId>draw.io</artifactId>" pom.xml | grep -m1 "<version>" | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "drawio_version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Update sources
+        run: ./scripts/update-drawio-sources.sh https://github.com/jgraph/drawio.git "v${{ steps.vars.outputs.drawio_version }}"
+      - name: Commit and push
+        run: |
+          git add drawio_sources/drawio
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "chore: sync draw.io sources to ${{ steps.vars.outputs.drawio_version }}"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ The script clones the official
 [`jgraph/drawio`](https://github.com/jgraph/drawio) repository by default and
 removes the JARs automatically. A `Refresh draw.io sources` workflow is also
 provided to run the script and push the changes.
+The current reference snapshot corresponds to tag `v27.1.6`
+(commit `7114e2037b400fabce0824bfc8f20703eeda5fd4`). Update this note whenever
+the sources are refreshed.
 
 
 

--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -2,10 +2,13 @@
 set -euo pipefail
 
 # Refresh the draw.io sources used only for reference when updating the WebJar.
-# Usage: ./scripts/update-drawio-sources.sh [git_url]
+# Usage: ./scripts/update-drawio-sources.sh [git_url] [git_ref]
 # If no git_url is provided, the official jgraph/drawio repository is used.
+# Optionally a git_ref (tag, branch or commit) can be specified to check out a
+# particular version.
 
 REPO_URL="${1:-https://github.com/jgraph/drawio.git}"
+GIT_REF="${2:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET_DIR="${SCRIPT_DIR}/../drawio_sources/drawio"
 
@@ -13,7 +16,11 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "Cloning $REPO_URL..."
- git clone --depth 1 "$REPO_URL" "$WORK_DIR/drawio"
+if [ -n "$GIT_REF" ]; then
+    git clone --depth 1 --branch "$GIT_REF" "$REPO_URL" "$WORK_DIR/drawio"
+else
+    git clone --depth 1 "$REPO_URL" "$WORK_DIR/drawio"
+fi
 
 # Sync the sources while removing previously deleted files
 rsync -a --delete "$WORK_DIR/drawio/" "$TARGET_DIR/"


### PR DESCRIPTION
## Summary
- document the current draw.io reference tag and commit
- allow specifying a git ref when updating the draw.io sources
- add a workflow to sync the reference sources to the WebJar version

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855f767cd10832180a00516b006b8cf