### PR TITLE
Fix draw.io WebJar build instructions

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio
       - name: Build draw.io WebJar
-        run: mvn -Pwebjar clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
+        run: mvn clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
       - name: Install WebJar to local Maven repo
         run: |

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ make sure to:
 To build a WebJar locally perform the following steps:
 
 1. Clone `https://github.com/seclution/draw.io`.
-2. Run `mvn -Pwebjar clean package` inside the cloned repository.
+2. Run `mvn clean package` inside the cloned repository.
 3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
    local Maven cache.
 4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
@@ -105,7 +105,7 @@ the draw.io WebJar from the [`seclution/draw.io`](https://github.com/seclution/d
 packaging repository as described in the *Updating to a newer draw.io version*
 section above.
 
-1. Clone the repository and run `mvn -Pwebjar clean package`.
+1. Clone the repository and run `mvn clean package`.
 2. Optionally install the generated jar with `mvn -pl draw.io-webjar install` so
    that it can be resolved by this project.
 3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`


### PR DESCRIPTION
## Summary
- remove the outdated `-Pwebjar` profile from build docs
- update GitHub action to build draw.io WebJar without the profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6855f9ce05bc8321985ba096bc35d926