### PR TITLE
Fix WebJar build step

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio
       - name: Build draw.io WebJar
-        run: mvn -Pwebjar clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
+        run: mvn -pl draw.io-webjar clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
       - name: Install WebJar to local Maven repo
         run: |


### PR DESCRIPTION
## Summary
- build only the `draw.io-webjar` module in GitHub Actions

## Testing
- `python3 scripts/check_samples.py`
- `mvn -B package --settings .github/maven-settings.xml` *(fails: transfer failed for parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6855fcbca41c832191789bc4bf099cc7