### PR TITLE
Update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ make sure to:
 To build a WebJar locally perform the following steps:
 
 1. Clone `https://github.com/seclution/draw.io`.
-2. Run `mvn -Pwebjar clean package` inside the cloned repository.
+2. Run `mvn -pl draw.io-webjar clean package` inside the cloned repository.
 3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
    local Maven cache.
 4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
@@ -108,13 +108,17 @@ the draw.io WebJar from the [`seclution/draw.io`](https://github.com/seclution/d
 packaging repository as described in the *Updating to a newer draw.io version*
 section above.
 
-1. Clone the repository and run `mvn -Pwebjar clean package`.
+1. Clone the repository and run `mvn -pl draw.io-webjar clean package`.
 2. Optionally install the generated jar with `mvn -pl draw.io-webjar install` so
    that it can be resolved by this project.
 3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
    to update `pom.xml` with the WebJar version you just built.
 4. From the root of this repository run `mvn package` to generate the XAR under
    `target/`.
+
+The upstream draw.io sources no longer include the `js/grapheditor` directory.
+The packaging repository already bundles the resources required by this
+application.
 
 For detailed instructions on building the WebJar see the lines 43&ndash;72 of
 this README.


### PR DESCRIPTION
## Summary
- update the WebJar build steps
- update diagram application instructions to mention missing `js/grapheditor`

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q test` *(fails: Could not transfer artifact from nexus.xwiki.org)*

------
https://chatgpt.com/codex/tasks/task_b_6855fcbd1e8c8321b81a52a73ab81b40