### PR TITLE
Fix submodule update script

### DIFF
--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -4,10 +4,13 @@ REPO_URL="${1:-https://github.com/jgraph/drawio.git}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET_DIR="${SCRIPT_DIR}/../drawio_sources/drawio"
 
-if [ ! -d "${TARGET_DIR}/.git" ]; then
-    git submodule add "$REPO_URL" "$TARGET_DIR"
-else
+if git submodule status "${TARGET_DIR}" >/dev/null 2>&1; then
+    if [ ! -d "${TARGET_DIR}/.git" ]; then
+        git submodule update --init "${TARGET_DIR}"
+    fi
     git -C "${TARGET_DIR}" remote set-url origin "$REPO_URL"
+else
+    git submodule add "$REPO_URL" "$TARGET_DIR"
 fi
 
 git submodule update --init --remote "${TARGET_DIR}"


### PR DESCRIPTION
## Summary
- handle cases where drawio submodule exists but isn't cloned

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855ff7b835c8321a48776ba46a6ee3f