### PR TITLE
Fix draw.io update script

### DIFF
--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -2,13 +2,15 @@
 set -euo pipefail
 REPO_URL="${1:-https://github.com/jgraph/drawio.git}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TARGET_DIR="${SCRIPT_DIR}/../drawio_sources/drawio"
+REPO_ROOT="${SCRIPT_DIR}/.."
+TARGET_DIR="${REPO_ROOT}/drawio_sources/drawio"
+RELATIVE_DIR="drawio_sources/drawio"
 
-if [ ! -d "${TARGET_DIR}/.git" ]; then
-    git submodule add "$REPO_URL" "$TARGET_DIR"
+if git submodule status "$RELATIVE_DIR" > /dev/null 2>&1; then
+    git submodule set-url "$RELATIVE_DIR" "$REPO_URL"
 else
-    git -C "${TARGET_DIR}" remote set-url origin "$REPO_URL"
+    git submodule add "$REPO_URL" "$RELATIVE_DIR"
 fi
 
-git submodule update --init --remote "${TARGET_DIR}"
+git submodule update --init --remote "$RELATIVE_DIR"
 echo "draw.io sources updated"


### PR DESCRIPTION
## Summary
- handle existing drawio submodule when refreshing sources

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855ff9ee6b8832186673c61d0ca1ef8