### PR TITLE
Allow selecting draw.io reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Instead, clone the dedicated [xwiki-contrib/draw.io](https://github.com/xwiki-co
 repository when building a new WebJar.
 When upgrading, do not commit the libraries located under `src/main/webapp/WEB-INF/lib`. They are produced by the draw.io build and should remain outside version control.
 Use `scripts/update-drawio-sources.sh` to refresh the sources when upgrading.
+You can pass a second argument to specify the tag or commit to check out.
 The files under `drawio_sources/drawio` are kept as a **Git submodule** pointing
 to the official [`jgraph/drawio`](https://github.com/jgraph/drawio) repository.
 `scripts/update-drawio-sources.sh` updates this submodule automatically and

--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 REPO_URL="${1:-https://github.com/jgraph/drawio.git}"
+# Optional git reference (tag or commit) to checkout
+REF="${2-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET_DIR="${SCRIPT_DIR}/../drawio_sources/drawio"
 
@@ -11,4 +13,9 @@ else
 fi
 
 git submodule update --init --remote "${TARGET_DIR}"
+
+if [ -n "${REF}" ]; then
+    git -C "${TARGET_DIR}" fetch
+    git -C "${TARGET_DIR}" checkout "${REF}"
+fi
 echo "draw.io sources updated"


### PR DESCRIPTION
## Summary
- make `update-drawio-sources.sh` accept an optional git reference
- document new argument in README

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855ffd2c59483218de35f795125baa0