### PR TITLE
Fix README integration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Diagram Application
 Create various types of diagrams using [draw.io](https://www.draw.io/).
 
 This is a simple application created using [AppWithinMinutes](http://extensions.xwiki.org/xwiki/bin/view/Extension/App+Within+Minutes+Application) and integrating [jgraph/draw.io](https://github.com/jgraph/draw.io/). It supports both editing and viewing diagrams. Each diagram is stored in a wiki page. It doesn't require any external services in order to work properly.
-See [docs/integration.md](docs/integration.md) for details on how the editor is embedded and configured.
-
-See [docs/integration.md](docs/integration.md) for details on how macros and WebJar paths integrate draw.io with XWiki.
+See [docs/integration.md](docs/integration.md) for integration details.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- keep a single concise link to docs/integration.md

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855ffd8743c83219112e692414c07df