### PR TITLE
Mention xmlstarlet dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To build a WebJar locally perform the following steps:
    local Maven cache.
 4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
    to update the dependency version in `pom.xml`.
+   This script relies on `xmlstarlet` being available in your `PATH`.
 
 The forked repository keeps the draw.io sources up to date and can be used as
 a starting point for additional build customization.
@@ -115,6 +116,7 @@ section above.
    that it can be resolved by this project.
 3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
    to update `pom.xml` with the WebJar version you just built.
+   Ensure `xmlstarlet` is installed before executing this script.
 4. From the root of this repository run `mvn package` to generate the XAR under
    `target/`.
 

--- a/scripts/update-webjar-version.sh
+++ b/scripts/update-webjar-version.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+# This script edits pom.xml using xmlstarlet which must be installed.
+if ! command -v xmlstarlet >/dev/null 2>&1; then
+    echo "Error: xmlstarlet is required but was not found in PATH." >&2
+    exit 1
+fi
+
 usage() {
     echo "Usage: $0 <path-to-draw.io-webjar> [--commit]" >&2
     exit 1


### PR DESCRIPTION
## Summary
- mention that scripts/update-webjar-version.sh relies on xmlstarlet
- add runtime check for xmlstarlet

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_6855fff5a06883219a15bff57d463977