### PR TITLE
Fix shell script warning

### DIFF
--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -6,7 +6,6 @@ REF="${2-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="${SCRIPT_DIR}/.."
 TARGET_DIR="${REPO_ROOT}/drawio_sources/drawio"
-RELATIVE_DIR="drawio_sources/drawio"
 
 
 if git submodule status "${TARGET_DIR}" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove unused variable from draw.io sources script

## Testing
- `python3 scripts/check_samples.py`
- `shellcheck scripts/update-drawio-sources.sh`


------
https://chatgpt.com/codex/tasks/task_b_685602860bc483218b1d6bf86a3f4895