### PR TITLE
Update README URLs to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Diagram Application
 
 Create various types of diagrams using [draw.io](https://www.draw.io/).
 
-This is a simple application created using [AppWithinMinutes](http://extensions.xwiki.org/xwiki/bin/view/Extension/App+Within+Minutes+Application) and integrating [jgraph/draw.io](https://github.com/jgraph/draw.io/). It supports both editing and viewing diagrams. Each diagram is stored in a wiki page. It doesn't require any external services in order to work properly.
+This is a simple application created using [AppWithinMinutes](https://extensions.xwiki.org/xwiki/bin/view/Extension/App+Within+Minutes+Application) and integrating [jgraph/draw.io](https://github.com/jgraph/draw.io/). It supports both editing and viewing diagrams. Each diagram is stored in a wiki page. It doesn't require any external services in order to work properly.
 See [docs/integration.md](docs/integration.md) for integration details.
 
 ## Development Notes
@@ -15,10 +15,10 @@ and note any important changes or debugging improvements.
 * Project Lead: [Oana-Lavinia Florean](https://www.xwiki.org/xwiki/bin/view/XWiki/OanaLaviniaFlorean)
 * [Documentation & Download](https://extensions.xwiki.org/xwiki/bin/view/Extension/Diagram+Application)
 * [Issue Tracker](https://jira.xwiki.org/browse/XADIAGRAM)
-* Communication: [Mailing List](http://dev.xwiki.org/xwiki/bin/view/Community/MailingLists), [IRC](http://dev.xwiki.org/xwiki/bin/view/Community/IRC)
+* Communication: [Mailing List](https://dev.xwiki.org/xwiki/bin/view/Community/MailingLists), [IRC](https://dev.xwiki.org/xwiki/bin/view/Community/IRC)
 * [Development Practices](https://dev.xwiki.org)
 * Minimal XWiki version supported: XWiki 14.10
-* License: LGPL 2.1+ for the application code. **But** since the application code uses draw.io API that is licensed under GPLv3 the combination [is also **GPLv3**](http://www.gnu.org/licenses/gpl-faq.html#AllCompatibility). This means that if you want to distribute a package that bundles the Diagram Application and its draw.io dependency then that package must be licensed under GPLv3.
+* License: LGPL 2.1+ for the application code. **But** since the application code uses draw.io API that is licensed under GPLv3 the combination [is also **GPLv3**](https://www.gnu.org/licenses/gpl-faq.html#AllCompatibility). This means that if you want to distribute a package that bundles the Diagram Application and its draw.io dependency then that package must be licensed under GPLv3.
 * Translations: N/A
 * Sonar Dashboard: N/A
 * Continuous Integration Status: [![Build Status](https://ci.xwiki.org/job/XWiki%20Contrib/job/application-diagram/job/master/badge/icon)](https://ci.xwiki.org/view/Contrib/job/XWiki%20Contrib/job/application-diagram/job/master/)


### PR DESCRIPTION
## Summary
- replace legacy http links in README with https

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_68560f9f03048321b0b52140baa02676