### PR TITLE
Fix macro reference description

### DIFF
--- a/src/main/resources/Diagram/DiagramTranslations.xml
+++ b/src/main/resources/Diagram/DiagramTranslations.xml
@@ -59,7 +59,7 @@ diagram.livetable.emptyvalue=-
 rendering.macro.diagram.name=Diagram
 rendering.macro.diagram.description=Displays a diagram.
 rendering.macro.diagram.parameter.reference.name=Reference
-rendering.macro.diagram.parameter.reference.description=rendering.macro.diagram.parameter.reference.description=The reference of the page that contains the diagram to display. E.g. for "http://.../Diagram/My%20Diagram/", enter "Diagram.My Diagram.WebHome". If this field is left blank, the macro looks for a child page named "Diagram" and if not found, displays a form to create a diagram.
+rendering.macro.diagram.parameter.reference.description=The reference of the page that contains the diagram to display. E.g. for "http://.../Diagram/My%20Diagram/", enter "Diagram.My Diagram.WebHome". If this field is left blank, the macro looks for a child page named "Diagram" and if not found, displays a form to create a diagram.
 rendering.macro.diagram.parameter.cached.name=Cached
 rendering.macro.diagram.parameter.cached.description=Whether to display the cached diagram image (faster) instead of rendering the diagram live (slower).
 diagram.macro.invalidReference=The specified page is not a diagram.


### PR DESCRIPTION
## Summary
- fix DiagramTranslations line so value does not include the key

## Testing
- `mvn -q test` *(fails: Could not download parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68560f9c857883218a34c99328331107