### PR TITLE
Refactor build workflow

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -4,10 +4,30 @@ on:
   pull_request:
   push:
     branches: ["**"]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Run unit tests
+        run: mvn -B test --settings .github/maven-settings.xml
+      - name: Validate sample diagrams
+        run: python3 scripts/check_samples.py
+
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' && github.event_name != 'push'
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK


### PR DESCRIPTION
## Summary
- split build GitHub Actions workflow
  - new `test` job for push & PR
  - gate heavy `build` job to manual/scheduled runs
- support manual `workflow_dispatch`

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_6856125e546c8321b2d026d5de621b45