### PR TITLE
Expose draw.io version property

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Determine draw.io version
         id: vars
         run: |
-          VERSION=$(grep -A2 "<artifactId>draw.io</artifactId>" pom.xml | grep -m1 "<version>" | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          VERSION=$(mvn help:evaluate -Dexpression=drawio.version -q -DforceStdout)
           echo "drawio_version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Determine draw.io version
         id: vars
         run: |
-          VERSION=$(grep -A2 "<artifactId>draw.io</artifactId>" pom.xml | grep -m1 "<version>" | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          VERSION=$(mvn help:evaluate -Dexpression=drawio.version -q -DforceStdout)
           echo "drawio_version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio

--- a/.github/workflows/sync-drawio-sources.yml
+++ b/.github/workflows/sync-drawio-sources.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Determine draw.io version
         id: vars
         run: |
-          VERSION=$(grep -A2 "<artifactId>draw.io</artifactId>" pom.xml | grep -m1 "<version>" | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          VERSION=$(mvn help:evaluate -Dexpression=drawio.version -q -DforceStdout)
           echo "drawio_version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Update sources
         run: ./scripts/update-drawio-sources.sh https://github.com/jgraph/drawio.git "v${{ steps.vars.outputs.drawio_version }}"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To build a WebJar locally perform the following steps:
 3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
    local Maven cache.
 4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
-   to update the dependency version in `pom.xml`.
+   to update the `drawio.version` property in `pom.xml`.
    This script relies on `xmlstarlet` being available in your `PATH`.
 
 The forked repository keeps the draw.io sources up to date and can be used as
@@ -115,7 +115,7 @@ section above.
 2. Optionally install the generated jar with `mvn -pl draw.io-webjar install` so
    that it can be resolved by this project.
 3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
-   to update `pom.xml` with the WebJar version you just built.
+   to update the `drawio.version` property with the WebJar version you just built.
    Ensure `xmlstarlet` is installed before executing this script.
 4. From the root of this repository run `mvn package` to generate the XAR under
    `target/`.
@@ -134,7 +134,7 @@ publishes the Diagram Application as a XAR when a tag or release is
 created. Ensure the `pom.xml` contains the correct draw.io version before
 tagging a release.
 
-1. Update `pom.xml` with the WebJar version using
+1. Update the `drawio.version` property in `pom.xml` using
    `scripts/update-webjar-version.sh` after building the WebJar from the
    [`seclution/draw.io`](https://github.com/seclution/draw.io) packaging
    repository.

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <!-- There are no java resources in this project. --> 
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <maven.compiler.release>11</maven.compiler.release>
+    <drawio.version>27.1.6</drawio.version>
   </properties>
   <dependencies>
     <dependency>
@@ -93,7 +94,7 @@
       <groupId>org.xwiki.contrib</groupId>
       <artifactId>draw.io</artifactId>
       <!-- Use a draw.io WebJar available on the XWiki Nexus -->
-      <version>27.1.6</version>
+      <version>${drawio.version}</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/scripts/update-webjar-version.sh
+++ b/scripts/update-webjar-version.sh
@@ -28,9 +28,9 @@ JAR_FILE="$(basename "$JAR_PATH")"
 VERSION="${JAR_FILE#draw.io-}"
 VERSION="${VERSION%.jar}"
 
-# Update pom.xml dependency version
+# Update pom.xml draw.io version property
 xmlstarlet ed -L \
-    -u "/_:project/_:dependencies/_:dependency[_:groupId='org.xwiki.contrib'][_:artifactId='draw.io']/_:version" \
+    -u "/_:project/_:properties/_:drawio.version" \
     -v "$VERSION" pom.xml
 
 echo "Updated pom.xml to use draw.io version $VERSION"


### PR DESCRIPTION
## Summary
- manage draw.io version via a Maven property
- update update-webjar-version script to modify the property
- read draw.io version in workflows using `mvn help:evaluate`
- document how to update the new property

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q -DskipTests package` *(fails: Could not transfer parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685612b6e094832198a2a470584fda49