### PR TITLE
Fix XML parsing compatibility in check_samples

### DIFF
--- a/scripts/check_samples.py
+++ b/scripts/check_samples.py
@@ -14,8 +14,8 @@ def check_file(path: pathlib.Path):
         if not diagrams:
             return 'No <diagram> elements found'
         for d in diagrams:
-            # Ensure the inner XML is well formed
-            ET.fromstring(d.tostring() if hasattr(d, 'tostring') else ET.tostring(d))
+            # Ensure the inner XML is well formed for both standard and lxml implementations
+            ET.fromstring(ET.tostring(d))
     except Exception as e:
         return str(e)
     return None


### PR DESCRIPTION
## Summary
- simplify the parsing logic by using `ET.fromstring(ET.tostring(d))`
- ensure compatibility with both standard `xml.etree` and lxml

## Testing
- `python3 scripts/check_samples.py`

------
https://chatgpt.com/codex/tasks/task_b_685612be0724832181b2307495d915c8