### PR TITLE
Update draw.io update script

### DIFF
--- a/scripts/update-drawio-sources.sh
+++ b/scripts/update-drawio-sources.sh
@@ -23,4 +23,8 @@ if [ -n "${REF}" ]; then
     git -C "${TARGET_DIR}" fetch
     git -C "${TARGET_DIR}" checkout "${REF}"
 fi
+TARGET_LIB_DIR="${TARGET_DIR}/src/main/webapp/WEB-INF/lib"
+if [ -d "${TARGET_LIB_DIR}" ]; then
+    find "${TARGET_LIB_DIR}" -name '*.jar' -delete
+fi
 echo "draw.io sources updated"


### PR DESCRIPTION
## Summary
- delete JARs from the draw.io submodule after refresh

## Testing
- `python3 scripts/check_samples.py`
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685612a97a1c8321a47212e5a5219d5b