### PR TITLE
Fix draw.io build workflow

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio
       - name: Build draw.io WebJar
-        run: mvn -pl draw.io-webjar clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
+        run: mvn -pl draw.io-webjar -am clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
       - name: Install WebJar to local Maven repo
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Clone draw.io packaging project
         run: git clone https://github.com/seclution/draw.io.git /tmp/drawio
       - name: Build draw.io WebJar
-        run: mvn -pl draw.io-webjar clean package -Ddraw.io.version=${{ steps.vars.outputs.drawio_version }} --settings ${{ github.workspace }}/.github/maven-settings.xml
+        run: mvn -pl draw.io-webjar -am clean package -Ddraw.io.version=${{ steps.vars.outputs.drawio_version }} --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
       - name: Install WebJar to local Maven repo
         run: |

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ make sure to:
 To build a WebJar locally perform the following steps:
 
 1. Clone `https://github.com/seclution/draw.io`.
-2. Run `mvn -pl draw.io-webjar clean package` inside the cloned repository.
-3. Optionally run `mvn -pl draw.io-webjar install` to install the jar in your
+2. Run `mvn -pl draw.io-webjar -am clean package` inside the cloned repository.
+3. Optionally run `mvn -pl draw.io-webjar -am install` to install the jar in your
    local Maven cache.
 4. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
    to update the `drawio.version` property in `pom.xml`.
@@ -111,8 +111,8 @@ the draw.io WebJar from the [`seclution/draw.io`](https://github.com/seclution/d
 packaging repository as described in the *Updating to a newer draw.io version*
 section above.
 
-1. Clone the repository and run `mvn -pl draw.io-webjar clean package`.
-2. Optionally install the generated jar with `mvn -pl draw.io-webjar install` so
+1. Clone the repository and run `mvn -pl draw.io-webjar -am clean package`.
+2. Optionally install the generated jar with `mvn -pl draw.io-webjar -am install` so
    that it can be resolved by this project.
 3. Run `scripts/update-webjar-version.sh /path/to/draw.io-webjar/target/*.jar`
    to update the `drawio.version` property with the WebJar version you just built.


### PR DESCRIPTION
## Summary
- build draw.io webjar with dependencies in CI
- document `-am` flag in README instructions

## Testing
- `python3 scripts/check_samples.py`
- `mvn -B test --settings .github/maven-settings.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856145c9f208321acee2be9f5386d6d