### PR TITLE
Fix release workflow by installing parent POM

### DIFF
--- a/.github/workflows/build-drawio-webjar.yml
+++ b/.github/workflows/build-drawio-webjar.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Build draw.io WebJar
         run: mvn -pl draw.io-webjar -am clean package --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
+      - name: Install draw.io parent POM
+        run: |
+          mvn install:install-file -Dfile=/tmp/drawio/pom.xml \
+            -DgroupId=org.xwiki.contrib -DartifactId=draw.io-parent \
+            -Dversion=${{ steps.vars.outputs.drawio_version }}-1-SNAPSHOT -Dpackaging=pom
       - name: Install WebJar to local Maven repo
         run: |
           JAR_PATH=$(ls /tmp/drawio/draw.io-webjar/target/*.jar | head -n1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
       - name: Build draw.io WebJar
         run: mvn -pl draw.io-webjar -am clean package -Ddraw.io.version=${{ steps.vars.outputs.drawio_version }} --settings ${{ github.workspace }}/.github/maven-settings.xml
         working-directory: /tmp/drawio
+      - name: Install draw.io parent POM
+        run: |
+          mvn install:install-file -Dfile=/tmp/drawio/pom.xml \
+            -DgroupId=org.xwiki.contrib -DartifactId=draw.io-parent \
+            -Dversion=${{ steps.vars.outputs.drawio_version }}-1-SNAPSHOT -Dpackaging=pom
       - name: Install WebJar to local Maven repo
         run: |
           JAR_PATH=$(ls /tmp/drawio/draw.io-webjar/target/*.jar | head -n1)


### PR DESCRIPTION
## Summary
- install `draw.io-parent` POM in build workflows

## Testing
- `python3 scripts/check_samples.py`
- `mvn -B test --settings .github/maven-settings.xml` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6856165746d08321901fc42cf21e5c0c